### PR TITLE
Update technical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,8 @@ This repository contains the Markdown content for the pages at https://docs.clas
 
 Contributions in the form of issues and pull requests to this repository are welcome. Once a pull request is merged, the corresponding changes will be synchronized to the main site.
 
-You can find more information about how this process works here: https://github.com/ClassicPress/site-docs#markdown-sync
+You can find more information about how to contribute to the documentation content here: https://forums.classicpress.net/t/contributing-to-the-classicpress-documentation/2176
+
+## Technical information
+
+You can find more information about the code that synchronizes documentation content from GitHub to docs.classicpress.net here: https://github.com/ClassicPress/site-docs#markdown-sync


### PR DESCRIPTION
Make it clearer that the linked instructions are not intended for people contributing to the documentation content, but rather for people contributing to the synchronization system and/or curious about how it works.

Also add a link to some contributor documentation on a forum thread.