### PR TITLE
Remove Privacy Policy

### DIFF
--- a/using-classicpress/index.md
+++ b/using-classicpress/index.md
@@ -3,4 +3,3 @@
 ClassicPress user documentation:
 
 - [Custom Login Image feature](https://docs.classicpress.net/using-classicpress/custom-login-image/)
-- [Privacy Policy](https://docs.classicpress.net/using-classicpress/privacy-policy/) (for the ClassicPress software itself)


### PR DESCRIPTION
We do not need lawyer talk on a user documentation that should show _how to work with ClassicPress_.
We already have sections on the main site that instruct how ClassicPress is a community, how its logos and names etc may or may not be used.
Thus, a `Privacy Policy (for the ClassicPress software itself)` link on a **Using ClassicPress** > **ClassicPress user documentation:** DOC is really inadequate.

Perhaps I miss something and it is meant to be a actual privacy policy doc about the `page` that (WP)CP generates for Privacy but then, we should be more precise on that, and additionally, we should never link dead stuff and this page is empty, thus, simply don't link it. 
It only makes bad impression.

I think on this screen we should link to the by now 2 sole and only new features of CP:
[Custom Login Image feature](https://docs.classicpress.net/using-classicpress/custom-login-image/)
[Security Page](https://docs.classicpress.net/developing-classicpress/security-page/)

However... even if that last page is a `/developing-classicpress/` and actually not linked from that main page, see https://docs.classicpress.net/developing-classicpress/, it is indeed a DEV page. A user page should not talk code.
It should talk usage.

So lets add that _later_, once we at least have a doc for the Custom Login Image Feature, which is as of now, undocumented
But I am on that now.